### PR TITLE
adding volatile to value where ADC output is stored to prevent compil…

### DIFF
--- a/cores/nRF5/wiring_analog_nRF52.c
+++ b/cores/nRF5/wiring_analog_nRF52.c
@@ -106,7 +106,7 @@ uint32_t analogRead( uint32_t ulPin )
   uint32_t pin = SAADC_CH_PSELP_PSELP_NC;
   uint32_t saadcResolution;
   uint32_t resolution;
-  int16_t value = 0;
+  volatile int16_t value = 0;
 
   if (ulPin >= PINS_COUNT) {
     return 0;


### PR DESCRIPTION
…er from code optimization which lead for wrong value returned by function