### PR TITLE
add extern "C" to hw_clock_hfxo_request and int hw_clock_hfxo_release

### DIFF
--- a/cores/nRF5/nordic/nrfx/mdk/nrf.h
+++ b/cores/nRF5/nordic/nrfx/mdk/nrf.h
@@ -73,10 +73,16 @@ POSSIBILITY OF SUCH DAMAGE.
     #ifndef NRF52_SERIES
         #define NRF52_SERIES
     #endif
+    #ifdef __cplusplus
+    extern "C" {
+    #endif
     #define nrf52_clock_hfxo_request hw_clock_hfxo_request
     #define nrf52_clock_hfxo_release hw_clock_hfxo_release
     int hw_clock_hfxo_request(void);
     int hw_clock_hfxo_release(void);
+    #ifdef __cplusplus
+    }
+    #endif
 #endif
 
 /* Define NRF53_SERIES for common use in nRF53 series devices. */
@@ -174,4 +180,3 @@ POSSIBILITY OF SUCH DAMAGE.
 #endif /* _WIN32 || __unix || __APPLE__ */
 
 #endif /* NRF_H */
-


### PR DESCRIPTION
Add extern "C" to hw_clock_hfxo_request and int hw_clock_hfxo_release declarations.

These functions are defined Arduino wiring.c, and there they are defined as `extern "C"`. They are not part of wiring.h though,
 but are only declared in `nrf.h`, where they don't have "C" linkage. So any attempt to use these functions in cpp code fails to link.