### PR TITLE
Override printf for Uart

### DIFF
--- a/cores/nRF5/Print.h
+++ b/cores/nRF5/Print.h
@@ -83,7 +83,8 @@ class Print
     size_t println(double, int = 2);
     size_t println(const Printable&);
     size_t println(void);
-    int    printf(const char* format, ...) __attribute__ ((format (printf, 2, 3)));
+
+    virtual int  printf(const char* format, ...);
 
     virtual void flush() { /* Empty implementation for backward compatibility */ }
 

--- a/cores/nRF5/Uart.cpp
+++ b/cores/nRF5/Uart.cpp
@@ -202,6 +202,15 @@ void Uart::end()
   rxBuffer.clear();
 }
 
+int Uart::printf(const char* format, ...)
+{
+  va_list va;
+  va_start(va, format);
+  int ret = vprintf(format, va);
+  va_end(va);
+  return ret;
+}
+
 void Uart::flush()
 {
 }

--- a/cores/nRF5/Uart.h
+++ b/cores/nRF5/Uart.h
@@ -43,6 +43,7 @@ class Uart : public HardwareSerial
     int read();
     void flush();
     size_t write(const uint8_t data);
+    int printf(const char* format, ...) override;
     using Print::write; // pull in write(str) and write(buf, size) from Print
 
     void IrqHandler();


### PR DESCRIPTION
Follow up to #64

Avoids the stack or malloc use when printing to the uart.