### PR TITLE
Allow USB CDC Serial to be disabled, redirect to UART

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ For example: `'-DCONFIG_MAIN_TASK_STACK_SIZE=512'` This will set the main task s
  * `CONFIG_WDT_TIMEOUT_SECONDS` - set the number of seconds before the watchdog times out (0 = disable watchdog, default = 0).
  * `CONFIG_PRINTF_BUFFER_SIZE` - set the size of the buffer used for `printf` and `Serial.printf` (default 128 bytes, set to 1 for no buffer).
  * `CONFIG_PRINTF_BUFFER_INDEX` - set the FreeRTOS storage pointer index used for managing the `printf` buffer (default 0).
+ * `USB_CDC_DEFAULT_SERIAL` - For devices with USB CDC support, this enables the USB CDC serial by default, set to 0 to disable (default 1), Serial will be redirected to the UART if this is disabled.
  * Nimble configuration options can also be included, the list of those can be found [here](https://h2zero.github.io/NimBLE-Arduino/md__command_line_config.html)
  * Other compiler options or definitions for other libraries can also be specified.
 

--- a/cores/nRF5/Arduino.h
+++ b/cores/nRF5/Arduino.h
@@ -54,16 +54,11 @@ void loop( void ) ;
   #include "WMath.h"
   #include "HardwareSerial.h"
   #include "pulse.h"
-#endif
-#include "delay.h"
-#include "binary.h"
-#ifdef __cplusplus
   #include "Uart.h"
 #endif
 
-#ifdef USE_TINYUSB
-  #include "Adafruit_USBD_CDC.h"
-#endif
+#include "delay.h"
+#include "binary.h"
 
 // Include board variant
 #include "variant.h"

--- a/cores/nRF5/TinyUSB/Adafruit_TinyUSB_ArduinoCore/Adafruit_TinyUSB_API.cpp
+++ b/cores/nRF5/TinyUSB/Adafruit_TinyUSB_ArduinoCore/Adafruit_TinyUSB_API.cpp
@@ -26,8 +26,9 @@
 
 #if CFG_TUD_ENABLED || CFG_TUH_ENABLED
 
-#include "Adafruit_USBD_Device.h"
 #include "Arduino.h"
+#include "Adafruit_USBD_Device.h"
+#include "Adafruit_USBD_CDC.h"
 
 extern "C" {
 

--- a/cores/nRF5/TinyUSB/Adafruit_TinyUSB_ArduinoCore/Adafruit_TinyUSB_nrf.cpp
+++ b/cores/nRF5/TinyUSB/Adafruit_TinyUSB_ArduinoCore/Adafruit_TinyUSB_nrf.cpp
@@ -31,6 +31,7 @@
 
 #include "Arduino.h"
 #include "Adafruit_USBD_Device.h"
+#include "Adafruit_TinyUSB_API.h"
 
 //--------------------------------------------------------------------+
 // MACRO TYPEDEF CONSTANT ENUM DECLARATION

--- a/cores/nRF5/TinyUSB/Adafruit_TinyUSB_ArduinoCore/Adafruit_USBD_CDC.h
+++ b/cores/nRF5/TinyUSB/Adafruit_TinyUSB_ArduinoCore/Adafruit_USBD_CDC.h
@@ -93,11 +93,9 @@ private:
   bool isValid(void) { return _instance != INVALID_INSTANCE; }
 };
 
-extern Adafruit_USBD_CDC SerialTinyUSB;
-
 // Built-in support "Serial" is assigned to TinyUSB CDC
 // CH32 defines Serial as alias in WSerial.h
-#if defined(USE_TINYUSB) && !defined(ARDUINO_ARCH_CH32)
+#if defined(USE_TINYUSB) && !defined(ARDUINO_ARCH_CH32) && USB_CDC_DEFAULT_SERIAL
 #define SerialTinyUSB Serial
 #endif
 

--- a/cores/nRF5/TinyUSB/Adafruit_TinyUSB_ArduinoCore/Adafruit_USBD_Device.cpp
+++ b/cores/nRF5/TinyUSB/Adafruit_TinyUSB_ArduinoCore/Adafruit_USBD_Device.cpp
@@ -259,7 +259,6 @@ bool Adafruit_USBD_Device::begin(uint8_t rhport) {
   config->bNumInterfaces = _itf_count;
 #endif
 #else
-  SerialTinyUSB.begin(115200);
 
   // Init device hardware and call tusb_init()
   TinyUSB_Port_InitDevice(rhport);

--- a/cores/nRF5/Uart.cpp
+++ b/cores/nRF5/Uart.cpp
@@ -256,7 +256,7 @@ Uart::operator bool() {
   #define NRF_UART0_IRQn UART0_IRQn
 #endif
 
-#if !defined(USB_CDC_DEFAULT_SERIAL)
+#if !USB_CDC_DEFAULT_SERIAL
 #  if defined(PIN_SERIAL_CTS) && defined(PIN_SERIAL_RTS)
       Uart Serial( NRF_UART0, NRF_UART0_IRQn, PIN_SERIAL_RX, PIN_SERIAL_TX, PIN_SERIAL_CTS, PIN_SERIAL_RTS );
 #  else

--- a/cores/nRF5/Uart.h
+++ b/cores/nRF5/Uart.h
@@ -28,6 +28,14 @@
 
 #include "variant.h"
 
+#ifndef USB_CDC_DEFAULT_SERIAL
+  #define USB_CDC_DEFAULT_SERIAL (0)
+#endif
+
+#if defined(USE_TINYUSB) && USB_CDC_DEFAULT_SERIAL
+  #include "Adafruit_USBD_CDC.h"
+#endif
+
 class Uart : public HardwareSerial
 {
   public:
@@ -78,7 +86,7 @@ class Uart : public HardwareSerial
 //
 // SERIAL_PORT_HARDWARE_OPEN  Hardware serial ports which are open for use.  Their RX & TX
 //                            pins are NOT connected to anything by default.
-#if defined(USB_CDC_DEFAULT_SERIAL)
+#if USB_CDC_DEFAULT_SERIAL
   #define SERIAL_PORT_MONITOR         Serial
   #define SERIAL_PORT_USBVIRTUAL      Serial
 

--- a/cores/nRF5/libc/printf/putchar.cpp
+++ b/cores/nRF5/libc/printf/putchar.cpp
@@ -68,7 +68,7 @@ extern "C"
             Serial.write((const uint8_t *)pbuf->buffer, pbuf->index);
             pbuf->index = 0;
         }
-#ifdef USB_CDC_DEFAULT_SERIAL
+#if USB_CDC_DEFAULT_SERIAL
         Serial.flush();
 #endif
     }
@@ -85,7 +85,7 @@ extern "C"
                 Serial.write('\r');
             }
             Serial.write(c);
-#ifdef USB_CDC_DEFAULT_SERIAL
+#if USB_CDC_DEFAULT_SERIAL
             Serial.flush();
 #endif
             return;

--- a/cores/nRF5/main.cpp
+++ b/cores/nRF5/main.cpp
@@ -69,6 +69,9 @@ int main( void )
 
   #ifdef USE_TINYUSB
   TinyUSBDevice.begin(0);
+  #if USB_CDC_DEFAULT_SERIAL
+  Serial.begin(115200);
+  #endif
   #endif
 
   _loopTaskHandle = xTaskCreateStatic(loopTask, "mlt", MAIN_TASK_STACK_SIZE,

--- a/cores/nRF5/utils/debug_utils.cpp
+++ b/cores/nRF5/utils/debug_utils.cpp
@@ -177,7 +177,7 @@ static size_t capture_backtrace(uint32_t* backtrace_buffer, size_t buffer_size, 
  */
 static void store_fault_to_ram(exception_frame* ef, uint32_t exc_return_val)
 {
-#ifdef USB_CDC_DEFAULT_SERIAL
+#if USB_CDC_DEFAULT_SERIAL
     volatile fault_data_t* fault = FAULT_DATA_ADDR;
     fault->magic = FAULT_DATA_MAGIC;
     fault->pc = ef->pc;
@@ -240,7 +240,7 @@ static void store_fault_to_ram(exception_frame* ef, uint32_t exc_return_val)
 static void print_exception_data(exception_frame* ef)
 {
 // If USB is used for Serial we must avoid using it in HardFault handler
-#ifndef USB_CDC_DEFAULT_SERIAL
+#if !USB_CDC_DEFAULT_SERIAL
     if (Serial)
     {
         Serial.println("\n======== HARD FAULT DETECTED ========");
@@ -320,7 +320,7 @@ static void print_exception_data(exception_frame* ef)
  */
 void check_and_report_fault()
 {
-#ifdef USB_CDC_DEFAULT_SERIAL
+#if USB_CDC_DEFAULT_SERIAL
     volatile fault_data_t* fault = FAULT_DATA_ADDR;
 
     if (fault->magic == FAULT_DATA_MAGIC)

--- a/variants/Seeed_XIAO_nRF52840_Sense/variant.h
+++ b/variants/Seeed_XIAO_nRF52840_Sense/variant.h
@@ -85,9 +85,17 @@ static const uint8_t A5  = PIN_A5;
 #define PIN_NFC2                (31)
 
 // Serial interfaces
-#define PIN_SERIAL1_RX          (7)
-#define PIN_SERIAL1_TX          (6)
-#define USB_CDC_DEFAULT_SERIAL  1
+#ifndef USB_CDC_DEFAULT_SERIAL
+  #define USB_CDC_DEFAULT_SERIAL (1)
+#endif
+
+#if USB_CDC_DEFAULT_SERIAL
+  #define PIN_SERIAL1_RX         (7)
+  #define PIN_SERIAL1_TX         (6)
+#else
+  #define PIN_SERIAL_RX          (7)
+  #define PIN_SERIAL_TX          (6)
+#endif
 
 // SPI Interfaces
 #define SPI_INTERFACES_COUNT    (2)

--- a/variants/circuitplayground_nrf52840/variant.h
+++ b/variants/circuitplayground_nrf52840/variant.h
@@ -92,9 +92,17 @@ static const uint8_t A9  = PIN_A9 ;
 /*
  * Serial interfaces
  */
-#define PIN_SERIAL1_RX       (0)
-#define PIN_SERIAL1_TX       (1)
-#define USB_CDC_DEFAULT_SERIAL 1
+#ifndef USB_CDC_DEFAULT_SERIAL
+  #define USB_CDC_DEFAULT_SERIAL (1)
+#endif
+
+#if USB_CDC_DEFAULT_SERIAL
+  #define PIN_SERIAL1_RX         (0)
+  #define PIN_SERIAL1_TX         (1)
+#else
+  #define PIN_SERIAL_RX          (0)
+  #define PIN_SERIAL_TX          (1)
+#endif
 
 /*
  * SPI Interfaces

--- a/variants/clue_nrf52840/variant.h
+++ b/variants/clue_nrf52840/variant.h
@@ -89,9 +89,17 @@ static const uint8_t A7  = PIN_A7 ;
 /*
  * Serial interfaces
  */
-#define PIN_SERIAL1_RX       (0)
-#define PIN_SERIAL1_TX       (1)
-#define USB_CDC_DEFAULT_SERIAL 1
+#ifndef USB_CDC_DEFAULT_SERIAL
+  #define USB_CDC_DEFAULT_SERIAL (1)
+#endif
+
+#if USB_CDC_DEFAULT_SERIAL
+  #define PIN_SERIAL1_RX         (0)
+  #define PIN_SERIAL1_TX         (1)
+#else
+  #define PIN_SERIAL_RX          (0)
+  #define PIN_SERIAL_TX          (1)
+#endif
 
 /*
  * SPI Interfaces

--- a/variants/feather_nrf52840_express/variant.h
+++ b/variants/feather_nrf52840_express/variant.h
@@ -91,9 +91,17 @@ static const uint8_t AREF = PIN_AREF;
 /*
  * Serial interfaces
  */
-#define PIN_SERIAL1_RX       (1)
-#define PIN_SERIAL1_TX       (0)
-#define USB_CDC_DEFAULT_SERIAL 1
+#ifndef USB_CDC_DEFAULT_SERIAL
+  #define USB_CDC_DEFAULT_SERIAL (1)
+#endif
+
+#if USB_CDC_DEFAULT_SERIAL
+  #define PIN_SERIAL1_RX         (1)
+  #define PIN_SERIAL1_TX         (0)
+#else
+  #define PIN_SERIAL_RX          (1)
+  #define PIN_SERIAL_TX          (0)
+#endif
 
 /*
  * SPI Interfaces

--- a/variants/feather_nrf52840_sense/variant.h
+++ b/variants/feather_nrf52840_sense/variant.h
@@ -96,9 +96,17 @@ static const uint8_t AREF = PIN_AREF;
 /*
  * Serial interfaces
  */
-#define PIN_SERIAL1_RX       (1)
-#define PIN_SERIAL1_TX       (0)
-#define USB_CDC_DEFAULT_SERIAL 1
+#ifndef USB_CDC_DEFAULT_SERIAL
+  #define USB_CDC_DEFAULT_SERIAL (1)
+#endif
+
+#if USB_CDC_DEFAULT_SERIAL
+  #define PIN_SERIAL1_RX         (1)
+  #define PIN_SERIAL1_TX         (0)
+#else
+  #define PIN_SERIAL_RX          (1)
+  #define PIN_SERIAL_TX          (0)
+#endif
 
 /*
  * SPI Interfaces

--- a/variants/itsybitsy_nrf52840_express/variant.h
+++ b/variants/itsybitsy_nrf52840_express/variant.h
@@ -86,9 +86,17 @@ static const uint8_t A6  = PIN_A6 ;
 /*
  * Serial interfaces
  */
-#define PIN_SERIAL1_RX       (0)
-#define PIN_SERIAL1_TX       (1)
-#define USB_CDC_DEFAULT_SERIAL 1
+#ifndef USB_CDC_DEFAULT_SERIAL
+  #define USB_CDC_DEFAULT_SERIAL (1)
+#endif
+
+#if USB_CDC_DEFAULT_SERIAL
+  #define PIN_SERIAL1_RX         (0)
+  #define PIN_SERIAL1_TX         (1)
+#else
+  #define PIN_SERIAL_RX          (0)
+  #define PIN_SERIAL_TX          (1)
+#endif
 
 /*
  * SPI Interfaces

--- a/variants/nRF52840_Dongle/variant.h
+++ b/variants/nRF52840_Dongle/variant.h
@@ -91,10 +91,17 @@ static const uint8_t AREF = PIN_AREF;
  */
 
 // Arduino Header D0, D1
-#define PIN_SERIAL1_RX      (33) // P1.01
-#define PIN_SERIAL1_TX      (34) // P1.02
-#define USB_CDC_DEFAULT_SERIAL 1
+#ifndef USB_CDC_DEFAULT_SERIAL
+  #define USB_CDC_DEFAULT_SERIAL (1)
+#endif
 
+#if USB_CDC_DEFAULT_SERIAL
+  #define PIN_SERIAL1_RX         (33)
+  #define PIN_SERIAL1_TX         (34)
+#else
+  #define PIN_SERIAL_RX          (33)
+  #define PIN_SERIAL_TX          (34)
+#endif
 
 /*
  * SPI Interfaces


### PR DESCRIPTION
This will set the default Serial output to UART if USB CDC is disabled by setting USB_CDC_DEFAULT_SERIAL to 0.

If the board has Serial1 pins defined they will be redefined to Serial.
