### PR TITLE
Add nice!nano v2 board support

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,10 +125,14 @@ board = ...
  2. Select adafruit-nrfutil as the firmware uploader in the tools menu.
 
 ### Uploading via UF2
-Boards with an Adafruit UF2 bootloader, such as the nice!nano v2, can be reset
-into the bootloader and programmed by copying the exported `.uf2` file to the
-mounted bootloader drive. UF2 export requires Python 3 to be available on the
-system path.
+Boards with an Adafruit UF2 bootloader, such as the nice!nano v2, can be
+programmed as follows:
+
+1. In the Arduino IDE, select `Sketch -> Export Compiled Binary`. UF2 export
+   requires Python 3 to be available on the system path.
+2. Double-press the board's reset button (or briefly connect RST to GND twice)
+   to enter the UF2 bootloader and wait for the bootloader drive to mount.
+3. Copy the exported `.uf2` file to the mounted bootloader drive.
 
 ### Uploading via (Nordic) nrfutil (for Nordic bootloader devices only)
  1. Install nrfutil if not already installed `pip install nrfutil`

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ This Arduino Core does **not** contain any BLE functionality. It has been design
  * [Adafruit Feather nRF52840 Sense](https://www.adafruit.com/product/4516)
  * [Adafruit ItsyBitsy nRF52840 Express](https://www.adafruit.com/product/4481)
  * [Ebyte E104-BT5040U](https://www.ebyte.com/en/product-view-news.html?id=1185)
+ * [nice!nano v2](https://nicekeyboards.com/docs/nice-nano/)
  * [XIAO nRF52840 Sense](https://wiki.seeedstudio.com/XIAO_BLE/)
 
 ### nRF52833
@@ -122,6 +123,12 @@ board = ...
 ### Uploading via adafruit-nrfutil (for Adafruit bootloader devices only)
  1. Install adafruit-nrfutil if not already installed `pip install adafruit-nrfutil`
  2. Select adafruit-nrfutil as the firmware uploader in the tools menu.
+
+### Uploading via UF2
+Boards with an Adafruit UF2 bootloader, such as the nice!nano v2, can be reset
+into the bootloader and programmed by copying the exported `.uf2` file to the
+mounted bootloader drive. UF2 export requires Python 3 to be available on the
+system path.
 
 ### Uploading via (Nordic) nrfutil (for Nordic bootloader devices only)
  1. Install nrfutil if not already installed `pip install nrfutil`

--- a/boards.txt
+++ b/boards.txt
@@ -989,6 +989,92 @@ BT5040.menu.bootloader.none.bootloader.flags=-DUSE_NORDIC_BL
 BT5040.menu.bootloader.none.build.bootloader.file=
 
 
+# Nice Keyboards
+
+nicenano_v2.name=nice!nano v2
+
+nicenano_v2.vid.0=0x239A
+nicenano_v2.pid.0=0x80B3
+nicenano_v2.vid.1=0x239A
+nicenano_v2.pid.1=0x00B3
+
+nicenano_v2.upload.tool=openocd
+nicenano_v2.upload.target=nrf52
+nicenano_v2.upload.jlink_device=nRF52840_xxAA
+nicenano_v2.upload.use_1200bps_touch=true
+nicenano_v2.upload.wait_for_upload_port=true
+nicenano_v2.upload.maximum_size=1032192
+nicenano_v2.upload.maximum_data_size=262144
+nicenano_v2.bootloader.tool=openocd
+
+nicenano_v2.build.dfu_pattern={adafruit-nrfutil.dfu_pattern}
+nicenano_v2.build.uf2_family=0xADA52840
+nicenano_v2.build.mcu=cortex-m4
+nicenano_v2.build.f_cpu=64000000
+nicenano_v2.build.board=NICE_NANO_V2
+nicenano_v2.build.core=nRF5
+nicenano_v2.build.variant=nice_nano_v2
+nicenano_v2.build.variant_system_lib=
+nicenano_v2.build.usb_manufacturer="Nice Keyboards"
+nicenano_v2.build.usb_product="nice!nano v2"
+nicenano_v2.build.extra_flags=-DNRF52_SERIES -DNRF52840_XXAA {bootloader.flags} {build.flags.usb} -DCONFIG_NIMBLE_CPP_LOG_LEVEL={build.cpp_debug} {build.nimble_flags}
+nicenano_v2.build.ldscript=nrf52840_s140_v6_adabl.ld
+nicenano_v2.build.lfclk_flags=-DUSE_LFXO
+nicenano_v2.build.vid=0x239A
+nicenano_v2.build.pid=0x80B3
+nicenano_v2.build.float_flags=-mfloat-abi=hard -mfpu=fpv4-sp-d16
+nicenano_v2.recipe.objcopy.uf2.pattern="{tools.uf2conv.cmd}" "{runtime.platform.path}/tools/uf2conv.py" -f {build.uf2_family} -o "{build.path}/{build.project_name}.uf2" "{build.path}/{build.project_name}.hex"
+nicenano_v2.recipe.output.tmp_file={build.project_name}.uf2
+nicenano_v2.recipe.output.save_file={build.project_name}.{build.variant}.uf2
+
+nicenano_v2.menu.role.all=All
+nicenano_v2.menu.role.all.build.nimble_flags=
+nicenano_v2.menu.role.periph=Peripheral
+nicenano_v2.menu.role.periph.build.nimble_flags=-DCONFIG_BT_NIMBLE_ROLE_CENTRAL_DISABLED -DCONFIG_BT_NIMBLE_ROLE_OBSERVER_DISABLED
+nicenano_v2.menu.role.adv=Advertiser
+nicenano_v2.menu.role.adv.build.nimble_flags=-DCONFIG_BT_NIMBLE_ROLE_CENTRAL_DISABLED -DCONFIG_BT_NIMBLE_ROLE_OBSERVER_DISABLED -DCONFIG_BT_NIMBLE_ROLE_PERIPHERAL_DISABLED
+nicenano_v2.menu.role.scan=Scanner
+nicenano_v2.menu.role.scan.build.nimble_flags=-DCONFIG_BT_NIMBLE_ROLE_CENTRAL_DISABLED -DCONFIG_BT_NIMBLE_ROLE_PERIPHERAL_DISABLED -DCONFIG_BT_NIMBLE_ROLE_CENTRAL_DISABLED
+nicenano_v2.menu.role.central=Client
+nicenano_v2.menu.role.central.build.nimble_flags=-DCONFIG_BT_NIMBLE_ROLE_PERIPHERAL_DISABLED -DCONFIG_BT_NIMBLE_ROLE_BROADCASTER_DISABLED
+
+nicenano_v2.menu.cppDbgLvl.none=None
+nicenano_v2.menu.cppDbgLvl.none.build.cpp_debug=0
+nicenano_v2.menu.cppDbgLvl.error=Error
+nicenano_v2.menu.cppDbgLvl.error.build.cpp_debug=1
+nicenano_v2.menu.cppDbgLvl.warn=Warn
+nicenano_v2.menu.cppDbgLvl.warn.build.cpp_debug=2
+nicenano_v2.menu.cppDbgLvl.info=Info
+nicenano_v2.menu.cppDbgLvl.info.build.cpp_debug=3
+nicenano_v2.menu.cppDbgLvl.debug=Debug
+nicenano_v2.menu.cppDbgLvl.debug.build.cpp_debug=4
+
+nicenano_v2.menu.bootloader.adafruit_ble=Adafruit BLE (s140 v6 softdevice)
+nicenano_v2.menu.bootloader.adafruit_ble.bootloader.flags=-DUSE_ADA_BL -DADA_SD_BL
+nicenano_v2.menu.bootloader.adafruit_ble.upload.tool=adafruit-nrfutil
+nicenano_v2.menu.bootloader.adafruit_ble.upload.protocol=adafruit-nrfutil
+nicenano_v2.menu.bootloader.adafruit_ble.upload.maximum_size=827392
+nicenano_v2.menu.bootloader.adafruit_ble.upload.maximum_data_size=237568
+nicenano_v2.menu.bootloader.adafruit_ble.build.dfu_pattern={adafruit-nrfutil.dfu_pattern}
+nicenano_v2.menu.bootloader.adafruit_ble.build.bootloader.file=tools/nrf52840_s140_v6_adabl.hex
+nicenano_v2.menu.bootloader.adafruit_ble.build.ldscript=nrf52840_s140_v6_adabl.ld
+
+nicenano_v2.menu.bootloader.adafruit_serial=Adafruit Serial (no softdevice)
+nicenano_v2.menu.bootloader.adafruit_serial.bootloader.flags=-DUSE_ADA_BL
+nicenano_v2.menu.bootloader.adafruit_serial.upload.tool=adafruit-nrfutil
+nicenano_v2.menu.bootloader.adafruit_serial.upload.protocol=adafruit-nrfutil
+nicenano_v2.menu.bootloader.adafruit_serial.upload.maximum_size=978944
+nicenano_v2.menu.bootloader.adafruit_serial.upload.maximum_data_size=262136
+nicenano_v2.menu.bootloader.adafruit_serial.build.dfu_pattern={adafruit-nrfutil.dfu_pattern}
+nicenano_v2.menu.bootloader.adafruit_serial.build.bootloader.file=tools/nrf52840_serial_adabl.hex
+nicenano_v2.menu.bootloader.adafruit_serial.build.ldscript=nrf52840_serial_adabl.ld
+
+nicenano_v2.menu.bootloader.none=No bootloader
+nicenano_v2.menu.bootloader.none.bootloader.flags=
+nicenano_v2.menu.bootloader.none.build.bootloader.file=tools/none_bootloader.hex
+nicenano_v2.menu.bootloader.none.build.ldscript=nrf52840_xxaa.ld
+
+
 # Seeedstudio
 
 seeed52840sense.name=Seeed XIAO nRF52840 Sense

--- a/platform.txt
+++ b/platform.txt
@@ -61,6 +61,8 @@ adafruit-nrfutil.dfu_pattern="{tools.adafruit-nrfutil.cmd}" dfu genpkg --dev-typ
 none.dfu_pattern.cmd=no_dfu
 none.dfu_pattern.cmd.windows=no_dfu.bat
 none.dfu_pattern.path={runtime.platform.path}/tools
+tools.uf2conv.cmd=python3
+tools.uf2conv.cmd.windows=python
 
 nordic.path={build.core.path}/nordic
 

--- a/tools/uf2conv.py
+++ b/tools/uf2conv.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+
+import argparse
+import struct
+import sys
+
+
+UF2_MAGIC_START0 = 0x0A324655
+UF2_MAGIC_START1 = 0x9E5D5157
+UF2_MAGIC_END = 0x0AB16F30
+UF2_FLAG_FAMILY_ID_PRESENT = 0x00002000
+UF2_PAYLOAD_SIZE = 256
+
+
+def parse_int(value):
+    return int(value, 0)
+
+
+def parse_hex_line(line, line_number):
+    line = line.strip()
+    if not line:
+        return None
+    if not line.startswith(":"):
+        raise ValueError(f"line {line_number}: missing ':'")
+
+    try:
+        raw = bytes.fromhex(line[1:])
+    except ValueError as exc:
+        raise ValueError(f"line {line_number}: invalid hex") from exc
+
+    if len(raw) < 5:
+        raise ValueError(f"line {line_number}: record is too short")
+
+    count = raw[0]
+    if len(raw) != count + 5:
+        raise ValueError(f"line {line_number}: record length mismatch")
+
+    if (sum(raw) & 0xFF) != 0:
+        raise ValueError(f"line {line_number}: checksum mismatch")
+
+    address = (raw[1] << 8) | raw[2]
+    record_type = raw[3]
+    payload = raw[4:4 + count]
+    return record_type, address, payload
+
+
+def read_ihex(filename):
+    data = {}
+    upper_address = 0
+
+    with open(filename, "r", encoding="ascii") as hex_file:
+        for line_number, line in enumerate(hex_file, 1):
+            record = parse_hex_line(line, line_number)
+            if record is None:
+                continue
+
+            record_type, address, payload = record
+            if record_type == 0x00:
+                absolute = upper_address + address
+                for offset, value in enumerate(payload):
+                    data[absolute + offset] = value
+            elif record_type == 0x01:
+                break
+            elif record_type == 0x02:
+                upper_address = int.from_bytes(payload, "big") << 4
+            elif record_type == 0x04:
+                upper_address = int.from_bytes(payload, "big") << 16
+            elif record_type in (0x03, 0x05):
+                continue
+            else:
+                raise ValueError(f"line {line_number}: unsupported record type {record_type:#x}")
+
+    if not data:
+        raise ValueError("input HEX contains no data records")
+
+    return data
+
+
+def build_blocks(data):
+    blocks = {}
+    for address, value in data.items():
+        block_address = address & ~(UF2_PAYLOAD_SIZE - 1)
+        if block_address not in blocks:
+            blocks[block_address] = bytearray([0xFF] * UF2_PAYLOAD_SIZE)
+        blocks[block_address][address - block_address] = value
+
+    return sorted(blocks.items())
+
+
+def write_uf2(blocks, family_id, output):
+    total = len(blocks)
+    with open(output, "wb") as uf2_file:
+        for index, (address, payload) in enumerate(blocks):
+            header = struct.pack(
+                "<IIIIIIII",
+                UF2_MAGIC_START0,
+                UF2_MAGIC_START1,
+                UF2_FLAG_FAMILY_ID_PRESENT,
+                address,
+                UF2_PAYLOAD_SIZE,
+                index,
+                total,
+                family_id,
+            )
+            block = header + bytes(payload)
+            block += bytes(512 - len(block) - 4)
+            block += struct.pack("<I", UF2_MAGIC_END)
+            uf2_file.write(block)
+
+
+def main(argv):
+    parser = argparse.ArgumentParser(description="Convert an Intel HEX file to UF2.")
+    parser.add_argument("-f", "--family", type=parse_int, required=True, help="UF2 family ID")
+    parser.add_argument("-o", "--output", required=True, help="output UF2 file")
+    parser.add_argument("input", help="input Intel HEX file")
+    args = parser.parse_args(argv)
+
+    data = read_ihex(args.input)
+    blocks = build_blocks(data)
+    write_uf2(blocks, args.family, args.output)
+    print(f"Wrote {args.output} ({len(blocks)} UF2 blocks)")
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/tools/uf2conv.py
+++ b/tools/uf2conv.py
@@ -41,18 +41,29 @@ def parse_hex_line(line, line_number):
     address = (raw[1] << 8) | raw[2]
     record_type = raw[3]
     payload = raw[4:4 + count]
+
+    required_lengths = {0x01: 0, 0x02: 2, 0x03: 4, 0x04: 2, 0x05: 4}
+    if record_type in required_lengths:
+        if count != required_lengths[record_type]:
+            raise ValueError(f"line {line_number}: invalid record length for type {record_type:#x}")
+        if address != 0:
+            raise ValueError(f"line {line_number}: non-zero address for type {record_type:#x}")
+
     return record_type, address, payload
 
 
 def read_ihex(filename):
     data = {}
     upper_address = 0
+    eof_seen = False
 
     with open(filename, "r", encoding="ascii") as hex_file:
         for line_number, line in enumerate(hex_file, 1):
             record = parse_hex_line(line, line_number)
             if record is None:
                 continue
+            if eof_seen:
+                raise ValueError(f"line {line_number}: record after EOF")
 
             record_type, address, payload = record
             if record_type == 0x00:
@@ -60,7 +71,7 @@ def read_ihex(filename):
                 for offset, value in enumerate(payload):
                     data[absolute + offset] = value
             elif record_type == 0x01:
-                break
+                eof_seen = True
             elif record_type == 0x02:
                 upper_address = int.from_bytes(payload, "big") << 4
             elif record_type == 0x04:
@@ -70,6 +81,8 @@ def read_ihex(filename):
             else:
                 raise ValueError(f"line {line_number}: unsupported record type {record_type:#x}")
 
+    if not eof_seen:
+        raise ValueError("input HEX is missing EOF record")
     if not data:
         raise ValueError("input HEX contains no data records")
 

--- a/variants/nice_nano_v2/variant.cpp
+++ b/variants/nice_nano_v2/variant.cpp
@@ -1,0 +1,45 @@
+#include "variant.h"
+#include "wiring_constants.h"
+#include "wiring_digital.h"
+#include "nrf.h"
+
+const uint32_t g_ADigitalPinMap[] =
+{
+  // nice!nano v2 edge castellations
+   8, // D0  is P0.08
+   6, // D1  is P0.06
+  17, // D2  is P0.17
+  20, // D3  is P0.20
+  22, // D4  is P0.22
+  24, // D5  is P0.24
+  32, // D6  is P1.00
+  11, // D7  is P0.11
+  36, // D8  is P1.04
+  38, // D9  is P1.06
+   9, // D10 is P0.09
+
+  // Exposed bottom pads
+  33, // D11 is P1.01
+  34, // D12 is P1.02
+  39, // D13 is P1.07
+
+  // nice!nano v2 edge castellations
+  43, // D14 is P1.11
+  45, // D15 is P1.13
+  10, // D16 is P0.10
+  42, // D17 is P1.10
+  47, // D18 is P1.15
+   2, // D19 is P0.02 (AIN0)
+  29, // D20 is P0.29 (AIN5)
+  31, // D21 is P0.31 (AIN7)
+
+  15, // D22 is P0.15 (status LED)
+   4, // D23 is P0.04 (battery voltage)
+  13, // D24 is P0.13 (VCC cutoff)
+};
+
+void initVariant()
+{
+  pinMode(PIN_LED, OUTPUT);
+  ledOff(PIN_LED);
+}

--- a/variants/nice_nano_v2/variant.h
+++ b/variants/nice_nano_v2/variant.h
@@ -1,0 +1,115 @@
+#ifndef _VARIANT_NICE_NANO_V2_
+#define _VARIANT_NICE_NANO_V2_
+
+#define TARGET_NICE_NANO_V2
+
+/** Master clock frequency */
+#define VARIANT_MCK       (64000000ul)
+
+#define USE_LFXO
+
+/*----------------------------------------------------------------------------
+ *        Headers
+ *----------------------------------------------------------------------------*/
+
+#include "WVariant.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif // __cplusplus
+
+#define PINS_COUNT              (25)
+#define NUM_DIGITAL_PINS        (25)
+#define NUM_ANALOG_INPUTS       (4)
+#define NUM_ANALOG_OUTPUTS      (0)
+
+// LEDs
+#define PIN_LED                 (22)
+#define LED_BUILTIN             PIN_LED
+#define LED_BLUE                PIN_LED
+#define LED_STATE_ON            (1)
+
+// Power control
+#define PIN_VCC_CUTOFF          (24)
+
+// Buttons
+#define PIN_BUTTON1             (PINS_COUNT)
+
+// Digital pins, matching the nice!nano v2 pinout labels.
+static const uint8_t D0  = 0;
+static const uint8_t D1  = 1;
+static const uint8_t D2  = 2;
+static const uint8_t D3  = 3;
+static const uint8_t D4  = 4;
+static const uint8_t D5  = 5;
+static const uint8_t D6  = 6;
+static const uint8_t D7  = 7;
+static const uint8_t D8  = 8;
+static const uint8_t D9  = 9;
+static const uint8_t D10 = 10;
+static const uint8_t D11 = 11;
+static const uint8_t D12 = 12;
+static const uint8_t D13 = 13;
+static const uint8_t D14 = 14;
+static const uint8_t D15 = 15;
+static const uint8_t D16 = 16;
+static const uint8_t D17 = 17;
+static const uint8_t D18 = 18;
+static const uint8_t D19 = 19;
+static const uint8_t D20 = 20;
+static const uint8_t D21 = 21;
+
+// Analog pins
+#define PIN_VBAT                (23)    // P0.04/AIN2, battery voltage
+#define PIN_A0                  (D19)   // P0.02/AIN0
+#define PIN_A1                  (D20)   // P0.29/AIN5
+#define PIN_A2                  (D21)   // P0.31/AIN7
+#define PIN_A3                  (PIN_VBAT)
+
+static const uint8_t A0 = PIN_A0;
+static const uint8_t A1 = PIN_A1;
+static const uint8_t A2 = PIN_A2;
+static const uint8_t A3 = PIN_A3;
+
+#define ADC_RESOLUTION          (14)
+
+// Serial interfaces
+#ifndef USB_CDC_DEFAULT_SERIAL
+  #define USB_CDC_DEFAULT_SERIAL (1)
+#endif
+
+#if USB_CDC_DEFAULT_SERIAL
+  #define PIN_SERIAL1_RX         (D0)
+  #define PIN_SERIAL1_TX         (D1)
+#else
+  #define PIN_SERIAL_RX          (D0)
+  #define PIN_SERIAL_TX          (D1)
+#endif
+
+// SPI interfaces
+#define SPI_INTERFACES_COUNT    (1)
+
+#define PIN_SPI_MISO            (D14)
+#define PIN_SPI_MOSI            (D16)
+#define PIN_SPI_SCK             (D15)
+
+static const uint8_t SS   = D10;
+static const uint8_t MOSI = PIN_SPI_MOSI;
+static const uint8_t MISO = PIN_SPI_MISO;
+static const uint8_t SCK  = PIN_SPI_SCK;
+
+// Wire interfaces
+#define WIRE_INTERFACES_COUNT   (1)
+
+#define PIN_WIRE_SDA            (D2)
+#define PIN_WIRE_SCL            (D3)
+
+static const uint8_t SDA = PIN_WIRE_SDA;
+static const uint8_t SCL = PIN_WIRE_SCL;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
 - Added nicenano_v2 board entry in boards.txt
  - Added variants/nice_nano_v2
  - Mapped Pro Micro-style Nice!Nano pins, LED, VBAT, VCC cutoff, UART, I2C, SPI
  - Added UF2 generation for Nice!Nano using family 0xADA52840
  - Added README docs for Nice!Nano and UF2 drag/drop

  Validation passed:

  - Blink-style sketch compiles
  - BLE_Advertiser NimBLE example compiles with NimBLE-Arduino 2.5.0
  - UF2 output starts at 0x26000
  - UF2 family is 0xADA52840
  - Generated UF2 matched Adafruit uf2conv.py byte-for-byte for the same HEX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the nice!nano v2 board, including pin mappings, LED initialization, USB settings, and configurable communication interfaces.
  * Added UF2 firmware export for compatible boards, including command-line conversion from Intel HEX files.
  * Added board options for bootloader type, wireless roles, and debug logging.

* **Documentation**
  * Added nice!nano v2 to the supported boards list.
  * Documented uploading firmware through UF2 bootloader mode, including the Python 3 requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->